### PR TITLE
chore(ng-dompurify): `DompurifyHook` mark deprecated

### DIFF
--- a/projects/ng-dompurify/lib/types/dompurify-hook.ts
+++ b/projects/ng-dompurify/lib/types/dompurify-hook.ts
@@ -2,6 +2,7 @@ import type {Config, HookEvent} from 'dompurify';
 
 /**
  * DOMPurify hook function {@link addHook}
+ * @deprecated will be removed in v5.0
  */
 export type DompurifyHook = (
     currentNode: Element,


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
